### PR TITLE
Using JSON responses, reenabled mysqldump for sql dumps

### DIFF
--- a/dbms/mysql/src/cloud/benchflow/collectors/mysql.go
+++ b/dbms/mysql/src/cloud/benchflow/collectors/mysql.go
@@ -1,15 +1,18 @@
 package main
  
 import (
-    "fmt"
     "net/http"
     "os"
     "os/exec"
     "github.com/benchflow/commons/minio"
     "github.com/benchflow/commons/kafka"
-    "log"
     "strings"
+    "encoding/json"
 )
+
+type Response struct {
+  Successful bool
+}
 
 func backupHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "PUT" {
@@ -17,55 +20,44 @@ func backupHandler(w http.ResponseWriter, r *http.Request) {
 		return	
 	}
 	// Generating key for Minio
-	//databaseMinioKey := minio.GenerateKey(os.Getenv("MYSQL_DB_NAME"))
 	databaseMinioKey := minio.GenerateKey(os.Getenv("MYSQL_DB_NAME"), os.Getenv("BENCHFLOW_TRIAL_ID"), os.Getenv("BENCHFLOW_EXPERIMENT_ID"), os.Getenv("BENCHFLOW_CONTAINER_NAME"), os.Getenv("BENCHFLOW_COLLECTOR_NAME"), os.Getenv("BENCHFLOW_DATA_NAME"))
-
-	log.Printf("Minio Key: " + databaseMinioKey)
+	
+	// Save whole database as mysqldump
+	cmd := exec.Command("mysqldump", "-h", os.Getenv("MYSQL_HOST"), "-P", os.Getenv("MYSQL_PORT"), "-u", os.Getenv("MYSQL_USER"), "-p" + os.Getenv("MYSQL_USER_PASSWORD"), os.Getenv("MYSQL_DB_NAME"))
+	outfile, err := os.Create("/app/"+os.Getenv("MYSQL_DB_NAME")+"_backup.sql")
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusInternalServerError)
+	    return
+    }
+    cmd.Stdout = outfile
+    cmd.Start()
+    err = cmd.Wait()
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusInternalServerError)
+	    return
+    }
+    outfile.Close()
+   
+    minio.GzipFile("/app/"+os.Getenv("MYSQL_DB_NAME")+"_backup.sql")
+    minio.SendGzipToMinio("/app/"+os.Getenv("MYSQL_DB_NAME")+"_backup.sql.gz", os.Getenv("MINIO_HOST"), os.Getenv("MINIO_PORT"), databaseMinioKey+"/"+os.Getenv("MYSQL_DB_NAME")+"_backup.sql", os.Getenv("MINIO_ACCESSKEYID"), os.Getenv("MINIO_SECRETACCESSKEY"))
+   
+	err = os.Remove("/app/"+os.Getenv("MYSQL_DB_NAME")+"_backup.sql.gz")
+	if err != nil {
+        http.Error(w, err.Error(), http.StatusInternalServerError)
+	    return
+    }
 	
 	// Retrieve table names
 	ev := os.Getenv("TABLE_NAMES")
     tables := strings.Split(ev, ",")
     
-    // cmdd := exec.Command("touch", "/app/backup.csv")
-    // cmdd.Run()
-    // cmdd.Wait()
-    // cmdd = exec.Command("chmod", "777", "/app/backup.csv")
-    // cmdd.Run()
-    // cmdd.Wait()
-    /*
-    for _,each := range tables {
-		cmd := exec.Command("mysqldump", "-h", os.Getenv("MYSQL_HOST"), "-P", os.Getenv("MYSQL_PORT"), "-u", os.Getenv("MYSQL_USER"), "-p" + os.Getenv("MYSQL_USER_PASSWORD"), os.Getenv("MYSQL_DB_NAME"), each)
-		outfile, err := os.Create("/app/"+each+"_backup.sql")
-	    if err != nil {
-	        fmt.Fprintf(w, "ERROR:  %s", err)
-	        panic(err)
-	    }
-	    cmd.Stdout = outfile
-	    err = cmd.Start()
-	    cmd.Wait()
-	    if err != nil {
-	        fmt.Fprintf(w, "ERROR:  %s", err)
-	        panic(err)
-	        }
-	    outfile.Close()
-	    minio.GzipFile("/app/"+each+"_backup.sql")
-		callMinioClient("/app/"+each+"_backup.sql.gz", os.Getenv("MINIO_ALIAS"), databaseMinioKey+"/"+each+".sql.gz")
-		err = os.Remove("/app/"+each+"_backup.sql.gz")
-		if err != nil {
-	        fmt.Fprintf(w, "ERROR:  %s", err)
-	        panic(err)
-	    }
-	}
-	*/
-    
     // Save Table sizes
-    cmd := exec.Command("mysql", "-h", os.Getenv("MYSQL_HOST"), "-P", os.Getenv("MYSQL_PORT"), "-u", os.Getenv("MYSQL_USER"), "-p" + os.Getenv("MYSQL_USER_PASSWORD"), "-e", "USE "+os.Getenv("MYSQL_DB_NAME")+"; select table_schema AS Db, sum(data_length+index_length) AS Bytes from information_schema.tables where table_schema='"+os.Getenv("MYSQL_DB_NAME")+"' group by 1;")
+    cmd = exec.Command("mysql", "-h", os.Getenv("MYSQL_HOST"), "-P", os.Getenv("MYSQL_PORT"), "-u", os.Getenv("MYSQL_USER"), "-p" + os.Getenv("MYSQL_USER_PASSWORD"), "-e", "USE "+os.Getenv("MYSQL_DB_NAME")+"; select table_schema AS Db, sum(data_length+index_length) AS Bytes from information_schema.tables where table_schema='"+os.Getenv("MYSQL_DB_NAME")+"' group by 1;")
     cmd2 := exec.Command("sed", "s/\\t/\",\"/g;s/^/\"/;s/$/\"/;s/\\n//g")
-    outfile, err := os.Create("/app/database_table_sizes_backup.csv")
-    // outfile, err := os.Open("/app/backup.csv")
+    outfile, err = os.Create("/app/database_table_sizes_backup.csv")
     if err != nil {
-        fmt.Fprintf(w, "ERROR:  %s", err)
-        panic(err)
+        http.Error(w, err.Error(), http.StatusInternalServerError)
+	    return
     }
     cmd2.Stdin, _ = cmd.StdoutPipe()
     cmd2.Stdout = outfile
@@ -73,18 +65,16 @@ func backupHandler(w http.ResponseWriter, r *http.Request) {
     cmd.Run()
     cmd2.Wait()
     if err != nil {
-        fmt.Fprintf(w, "ERROR:  %s", err)
-        panic(err)
+        http.Error(w, err.Error(), http.StatusInternalServerError)
+	    return
     }
     outfile.Close()
     minio.GzipFile("/app/database_table_sizes_backup.csv")
-    //callMinioClient("/app/database_table_sizes_backup.csv.gz", os.Getenv("MINIO_ALIAS"), databaseMinioKey+"/database_table_sizes.csv.gz")
     minio.SendGzipToMinio("/app/database_table_sizes_backup.csv.gz", os.Getenv("MINIO_HOST"), os.Getenv("MINIO_PORT"), databaseMinioKey+"/database_table_sizes.csv.gz", os.Getenv("MINIO_ACCESSKEYID"), os.Getenv("MINIO_SECRETACCESSKEY"))
-	//minio.StoreOnMinio("backup.csv.gz", "runs", databaseMinioKey+each+".csv.gz")
 	err = os.Remove("/app/database_table_sizes_backup.csv.gz")
 	if err != nil {
-        fmt.Fprintf(w, "ERROR:  %s", err)
-        panic(err)
+        http.Error(w, err.Error(), http.StatusInternalServerError)
+	    return
     }
 	
     
@@ -93,10 +83,9 @@ func backupHandler(w http.ResponseWriter, r *http.Request) {
 	    cmd := exec.Command("mysql", "-h", os.Getenv("MYSQL_HOST"), "-P", os.Getenv("MYSQL_PORT"), "-u", os.Getenv("MYSQL_USER"), "-p" + os.Getenv("MYSQL_USER_PASSWORD"), "-e", "USE "+os.Getenv("MYSQL_DB_NAME")+"; SELECT * FROM "+each+";")
 	    cmd2 := exec.Command("sed", "s/\\t/\",\"/g;s/^/\"/;s/$/\"/;s/\\n//g")
 	    outfile, err := os.Create("/app/"+each+"_backup.csv")
-	    // outfile, err := os.Open("/app/backup.csv")
 	    if err != nil {
-	        fmt.Fprintf(w, "ERROR:  %s", err)
-	        panic(err)
+	        http.Error(w, err.Error(), http.StatusInternalServerError)
+	    	return
 	    }
 	    cmd2.Stdin, _ = cmd.StdoutPipe()
 	    cmd2.Stdout = outfile
@@ -104,37 +93,27 @@ func backupHandler(w http.ResponseWriter, r *http.Request) {
 	    cmd.Run()
 	    cmd2.Wait()
 	    if err != nil {
-	        fmt.Fprintf(w, "ERROR:  %s", err)
-	        panic(err)
+	        http.Error(w, err.Error(), http.StatusInternalServerError)
+	    	return
 	    }
 	    outfile.Close()
 	    minio.GzipFile("/app/"+each+"_backup.csv")
-	    //callMinioClient("/app/"+each+"_backup.csv.gz", os.Getenv("MINIO_ALIAS"), databaseMinioKey+"/"+each+".csv.gz")
 	    minio.SendGzipToMinio("/app/"+each+"_backup.csv.gz", os.Getenv("MINIO_HOST"), os.Getenv("MINIO_PORT"), databaseMinioKey+"/"+each+".csv.gz", os.Getenv("MINIO_ACCESSKEYID"), os.Getenv("MINIO_SECRETACCESSKEY"))
-		//minio.StoreOnMinio("backup.csv.gz", "runs", databaseMinioKey+each+".csv.gz")
 		err = os.Remove("/app/"+each+"_backup.csv.gz")
 		if err != nil {
-	        fmt.Fprintf(w, "ERROR:  %s", err)
-	        panic(err)
+	        http.Error(w, err.Error(), http.StatusInternalServerError)
+	    	return
 	    }
 	}
-    
-    // cmdd = exec.Command("touch", "/app/backup.csv")
-    // cmdd.Run()
-    // cmdd.Wait()
-    // cmdd = exec.Command("chmod", "777", "/app/backup.csv")
-    // cmdd.Run()
-    // cmdd.Wait()
     
     // Save the column types of the tables
     for _, each := range tables {
 	    cmd := exec.Command("mysql", "-h", os.Getenv("MYSQL_HOST"), "-P", os.Getenv("MYSQL_PORT"), "-u", os.Getenv("MYSQL_USER"), "-p" + os.Getenv("MYSQL_USER_PASSWORD"), "-e", "USE "+os.Getenv("MYSQL_DB_NAME")+"; SHOW FIELDS FROM "+each+";")
 	    cmd2 := exec.Command("sed", "s/\\t/\",\"/g;s/^/\"/;s/$/\"/;s/\\n//g")
 	    outfile, err := os.Create("/app/"+each+"_backup_schema.csv")
-	    // outfile, err := os.Open("/app/backup.csv")
 	    if err != nil {
-	        fmt.Fprintf(w, "ERROR:  %s", err)
-	        panic(err)
+	        http.Error(w, err.Error(), http.StatusInternalServerError)
+	    	return
 	    }
 	    cmd2.Stdin, _ = cmd.StdoutPipe()
 	    cmd2.Stdout = outfile
@@ -142,22 +121,29 @@ func backupHandler(w http.ResponseWriter, r *http.Request) {
 	    cmd.Run()
 	    cmd2.Wait()
 	    if err != nil {
-	        fmt.Fprintf(w, "ERROR:  %s", err)
-	        panic(err)
+	        http.Error(w, err.Error(), http.StatusInternalServerError)
+	    	return
 	    }
 	    outfile.Close()
 	    minio.GzipFile("/app/"+each+"_backup_schema.csv")
-	    //callMinioClient("/app/"+each+"_backup_schema.csv.gz", os.Getenv("MINIO_ALIAS"), databaseMinioKey+"/"+each+"_schema.csv.gz")
 	    minio.SendGzipToMinio("/app/"+each+"_backup_schema.csv.gz", os.Getenv("MINIO_HOST"), os.Getenv("MINIO_PORT"), databaseMinioKey+"/"+each+"_schema.csv.gz", os.Getenv("MINIO_ACCESSKEYID"), os.Getenv("MINIO_SECRETACCESSKEY"))
-		//minio.StoreOnMinio("backup.csv.gz", "runs", databaseMinioKey+each+"_schema.csv.gz")
 		err = os.Remove("/app/"+each+"_backup_schema.csv.gz")
 		if err != nil {
-	        fmt.Fprintf(w, "ERROR:  %s", err)
-	        panic(err)
+	        http.Error(w, err.Error(), http.StatusInternalServerError)
+	    	return
 	    }
 	}
     kafka.SignalOnKafka(databaseMinioKey, os.Getenv("BENCHFLOW_TRIAL_ID"), os.Getenv("BENCHFLOW_EXPERIMENT_ID"), "mysql", "mysql", "host", os.Getenv("BENCHFLOW_COLLECTOR_NAME"), os.Getenv("KAFKA_HOST"), os.Getenv("KAFKA_PORT"), os.Getenv("KAFKA_TOPIC"))
-	fmt.Fprintf(w, "SUCCESS")
+	
+	response := Response{true}
+	js, err := json.Marshal(response)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	    return
+    }
+    
+    w.Header().Set("Content-Type", "application/json")
+    w.Write(js)
 }
  
 func main() {

--- a/environment/properties/src/cloud/benchflow/collectors/properties.go
+++ b/environment/properties/src/cloud/benchflow/collectors/properties.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -9,7 +8,12 @@ import (
 	"github.com/fsouza/go-dockerclient"
 	"github.com/benchflow/commons/minio"
 	"github.com/benchflow/commons/kafka"
+	"encoding/json"
 )
+
+type Response struct {
+  Successful bool
+}
 
 func createDockerClient() docker.Client {
 	endpoint := "unix:///var/run/docker.sock"
@@ -29,13 +33,15 @@ func storeData(w http.ResponseWriter, r *http.Request) {
 	
 	info, err := client.Info()
 	if err != nil {
-		panic(err)
-		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+    	return
+	}
 	
 	version, err := client.Version()
 	if err != nil {
-		panic(err)
-		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+    	return
+	}
 	
 	contEV := os.Getenv("CONTAINERS")
 	conts := strings.Split(contEV, ",")
@@ -48,21 +54,25 @@ func storeData(w http.ResponseWriter, r *http.Request) {
 		
 		foInspect, err := os.Create("/app/"+each+"_inspect_tmp")
 		if err != nil {
-	        panic(err)
-	    }
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+	    	return
+		}
 		foInfo, err := os.Create("/app/"+each+"_info_tmp")
 		if err != nil {
-	        panic(err)
-	    }
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+	    	return
+		}
 		foVersion, err := os.Create("/app/"+each+"_version_tmp")
 		if err != nil {
-	        panic(err)
-	    }
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+	    	return
+		}
 		
 		inspect, err := client.InspectContainer(each)
 		if err != nil {
-			panic(err)
-			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+	    	return
+		}
 		e.SetJSON("inspect", inspect)
 		foInspect.Write([]byte(e.Get("inspect")))
 		
@@ -76,42 +86,50 @@ func storeData(w http.ResponseWriter, r *http.Request) {
 		minio.GzipFile("/app/"+each+"_info_tmp")
 		minio.GzipFile("/app/"+each+"_version_tmp")
 		
-		//minioKey := minio.GenerateKey(each)
 		minioKey := minio.GenerateKey(each, os.Getenv("BENCHFLOW_TRIAL_ID"), os.Getenv("BENCHFLOW_EXPERIMENT_ID"), os.Getenv("BENCHFLOW_CONTAINER_NAME"), os.Getenv("BENCHFLOW_COLLECTOR_NAME"), os.Getenv("BENCHFLOW_DATA_NAME"))
 		composedMinioKey = composedMinioKey+minioKey+","
 		composedContainerIds = composedContainerIds+inspect.ID+","
 		cName := strings.Split(each, "_")[0]
 		composedContainerNames = composedContainerIds+cName+","
 		
-		fmt.Println(minioKey)
-		
-		//callMinioClient("/app/"+each+"_inspect_tmp.gz", os.Getenv("MINIO_ALIAS"), minioKey+"_inspect.gz")
 		minio.SendGzipToMinio("/app/"+each+"_inspect_tmp.gz", os.Getenv("MINIO_HOST"), os.Getenv("MINIO_PORT"), minioKey+"_inspect.gz", os.Getenv("MINIO_ACCESSKEYID"), os.Getenv("MINIO_SECRETACCESSKEY"))
-		//callMinioClient("/app/"+each+"_info_tmp.gz", os.Getenv("MINIO_ALIAS"), minioKey+"_info.gz")
+		
 		minio.SendGzipToMinio("/app/"+each+"_info_tmp.gz", os.Getenv("MINIO_HOST"), os.Getenv("MINIO_PORT"), minioKey+"_info.gz", os.Getenv("MINIO_ACCESSKEYID"), os.Getenv("MINIO_SECRETACCESSKEY"))
-		//callMinioClient("/app/"+each+"_version_tmp.gz", os.Getenv("MINIO_ALIAS"), minioKey+"_version.gz")
+		
 		minio.SendGzipToMinio("/app/"+each+"_version_tmp.gz", os.Getenv("MINIO_HOST"), os.Getenv("MINIO_PORT"), minioKey+"_version.gz", os.Getenv("MINIO_ACCESSKEYID"), os.Getenv("MINIO_SECRETACCESSKEY"))
 		
 		err = os.Remove("/app/"+each+"_inspect_tmp.gz")
 		if err != nil {
-	        panic(err)
+	        http.Error(w, err.Error(), http.StatusInternalServerError)
+	    	return
 	    }
 		err = os.Remove("/app/"+each+"_info_tmp.gz")
 		if err != nil {
-	        panic(err)
+	        http.Error(w, err.Error(), http.StatusInternalServerError)
+	    	return
 	    }
 		err = os.Remove("/app/"+each+"_version_tmp.gz")
 		if err != nil {
-	        panic(err)
+	        http.Error(w, err.Error(), http.StatusInternalServerError)
+	    	return
 	    }
 	}
 	composedMinioKey = strings.TrimRight(composedMinioKey, ",")
 	composedContainerIds = strings.TrimRight(composedContainerIds, ",")
 	composedContainerNames = strings.TrimRight(composedContainerNames, ",")
-	fmt.Println(composedMinioKey)
-	//kafka.SignalOnKafka(composedMinioKey, composedContainerIds)
+	
 	kafka.SignalOnKafka(composedMinioKey, os.Getenv("BENCHFLOW_TRIAL_ID"), os.Getenv("BENCHFLOW_EXPERIMENT_ID"), composedContainerIds, composedContainerNames, hostID, os.Getenv("BENCHFLOW_COLLECTOR_NAME"), os.Getenv("KAFKA_HOST"), os.Getenv("KAFKA_PORT"), os.Getenv("KAFKA_TOPIC"))
-	}
+	
+	response := Response{true}
+	js, err := json.Marshal(response)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	    return
+    }
+    
+    w.Header().Set("Content-Type", "application/json")
+    w.Write(js)
+}
 
 func main() {
 	http.HandleFunc("/store", storeData)

--- a/environment/stats/src/cloud/benchflow/collectors/stats.go
+++ b/environment/stats/src/cloud/benchflow/collectors/stats.go
@@ -17,7 +17,20 @@ import (
 )
 
 type Response struct {
-  Successful bool
+  Status string
+  Message string
+}
+
+func writeJSONResponse(w http.ResponseWriter, status string, message string) {
+	response := Response{status, message}
+	js, err := json.Marshal(response)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		fmt.Println(err)
+	    return
+    }
+    w.Header().Set("Content-Type", "application/json")
+    w.Write(js)	
 }
 
 type Container struct {
@@ -176,7 +189,8 @@ func startCollecting(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if collecting {
-		fmt.Fprintf(w, "Already collecting")
+		writeJSONResponse(w, "FAILED", "Collection already in progress")
+		fmt.Println("Collection already in progress")
 		return
 	}
 
@@ -229,15 +243,8 @@ func startCollecting(w http.ResponseWriter, r *http.Request) {
 	}
 	collecting = true
 	
-	response := Response{true}
-	js, err := json.Marshal(response)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	    return
-    }
-    
-    w.Header().Set("Content-Type", "application/json")
-    w.Write(js)
+	writeJSONResponse(w, "SUCCESS", "The collection was started successfully for "+os.Getenv("BENCHFLOW_TRIAL_ID"))
+	fmt.Println("The collection was started successfully for "+os.Getenv("BENCHFLOW_TRIAL_ID"))
 }
 
 func stopCollecting(w http.ResponseWriter, r *http.Request) {
@@ -246,7 +253,8 @@ func stopCollecting(w http.ResponseWriter, r *http.Request) {
 		return	
 	}
 	if !collecting {
-		w.WriteHeader(405)
+		writeJSONResponse(w, "FAILED", "No collection in progress")
+		fmt.Println("No collection in progress")
 		return
 	}
 	close(stopChannel)
@@ -274,17 +282,20 @@ func stopCollecting(w http.ResponseWriter, r *http.Request) {
 		err := os.Remove("/app/"+container.Name+"_stats_tmp.gz")
 		if err != nil {
 	        http.Error(w, err.Error(), http.StatusInternalServerError)
+	        fmt.Println(err)
     		return
 	    }
 		if container.Network == "host" {
 			err = os.Remove("/app/"+container.Name+"_network_tmp.gz")
 			if err != nil {
 		        http.Error(w, err.Error(), http.StatusInternalServerError)
+		        fmt.Println(err)
 	    		return
 		    }
 			err = os.Remove("/app/"+container.Name+"_top_tmp.gz")
 			if err != nil {
 		        http.Error(w, err.Error(), http.StatusInternalServerError)
+		        fmt.Println(err)
 	    		return
 		    }
 		}
@@ -294,15 +305,8 @@ func stopCollecting(w http.ResponseWriter, r *http.Request) {
 	composedContainerNames = strings.TrimRight(composedContainerNames, ",")
 	kafka.SignalOnKafka(composedMinioKey, os.Getenv("BENCHFLOW_TRIAL_ID"), os.Getenv("BENCHFLOW_EXPERIMENT_ID"), composedContainerIds, composedContainerNames, hostID, os.Getenv("BENCHFLOW_COLLECTOR_NAME"), os.Getenv("KAFKA_HOST"), os.Getenv("KAFKA_PORT"), os.Getenv("KAFKA_TOPIC"))
 	
-	response := Response{true}
-	js, err := json.Marshal(response)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	    return
-    }
-    
-    w.Header().Set("Content-Type", "application/json")
-    w.Write(js)
+	writeJSONResponse(w, "SUCCESS", "The collection was performed successfully for "+os.Getenv("BENCHFLOW_TRIAL_ID"))
+	fmt.Println("The collection was performed successfully for "+os.Getenv("BENCHFLOW_TRIAL_ID"))
 }
 
 func main() {

--- a/files/zip/src/cloud/benchflow/collectors/zip.go
+++ b/files/zip/src/cloud/benchflow/collectors/zip.go
@@ -12,7 +12,20 @@ import (
 )
 
 type Response struct {
-  Successful bool
+  Status string
+  Message string
+}
+
+func writeJSONResponse(w http.ResponseWriter, status string, message string) {
+	response := Response{status, message}
+	js, err := json.Marshal(response)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		fmt.Println(err)
+	    return
+    }
+    w.Header().Set("Content-Type", "application/json")
+    w.Write(js)	
 }
  
 func backupHandler(w http.ResponseWriter, r *http.Request) {
@@ -37,15 +50,8 @@ func backupHandler(w http.ResponseWriter, r *http.Request) {
 	}
     kafka.SignalOnKafka(minioKey, os.Getenv("BENCHFLOW_TRIAL_ID"), os.Getenv("BENCHFLOW_EXPERIMENT_ID"), "files", "files", "host", os.Getenv("BENCHFLOW_COLLECTOR_NAME"), os.Getenv("KAFKA_HOST"), os.Getenv("KAFKA_PORT"), os.Getenv("KAFKA_TOPIC"))
 	
-	response := Response{true}
-	js, err := json.Marshal(response)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	    return
-    }
-    
-    w.Header().Set("Content-Type", "application/json")
-    w.Write(js)
+	writeJSONResponse(w, "SUCCESS", "The collection was performed successfully for "+os.Getenv("BENCHFLOW_TRIAL_ID"))
+	fmt.Println("The collection was performed successfully for "+os.Getenv("BENCHFLOW_TRIAL_ID"))
 }
 
 func main() {


### PR DESCRIPTION
Fixes #83
Improves #85 

<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/benchflow/collectors/pull/89%23discussion_r75838420%22%2C%20%22https%3A//github.com/benchflow/collectors/pull/89%23issuecomment-241689267%22%2C%20%22https%3A//github.com/benchflow/collectors/pull/89%23discussion_r75841700%22%2C%20%22https%3A//github.com/benchflow/collectors/pull/89%23issuecomment-241732942%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/benchflow/collectors/pull/89%23issuecomment-241689267%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Missing%20from%20https%3A//github.com/benchflow/collectors/issues/85%3A%5Cr%5Cn%5Cr%5Cn-%20The%20structure%20of%20the%20response%20is%20not%20as%20described.%20Moreover%20it%20should%20be%20placed%20in%20commons.%5Cr%5Cn-%20Of%20course%20the%20same%20information%20should%20be%20printed%20on%20the%20standard%20output%20of%20the%20collectors%22%2C%20%22created_at%22%3A%20%222016-08-23T10%3A21%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40VincenzoFerme%20Altered%20the%20structure%20to%20fit%20the%20issue%20description%22%2C%20%22created_at%22%3A%20%222016-08-23T13%3A37%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8819678%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Cerfoglg%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20e0c8b5a26af9df973fa422ac7b2e9dd9c468011d%20dbms/mysql/src/cloud/benchflow/collectors/mysql.go%2049%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/benchflow/collectors/pull/89%23discussion_r75838420%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20are%20not%20removing%20the%20sql%20file%22%2C%20%22created_at%22%3A%20%222016-08-23T10%3A18%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7163641%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VincenzoFerme%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40VincenzoFerme%20When%20you%20gzip%20something%20it%20overwirtes%20the%20uncompressed%20file%2C%20so%20I%20only%20have%20to%20remove%20the%20gzipped%20file%20because%20that%27s%20all%20there%20is.%22%2C%20%22created_at%22%3A%20%222016-08-23T10%3A43%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8819678%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Cerfoglg%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20dbms/mysql/src/cloud/benchflow/collectors/mysql.go%3AL1-81%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull e0c8b5a26af9df973fa422ac7b2e9dd9c468011d dbms/mysql/src/cloud/benchflow/collectors/mysql.go 49'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/benchflow/collectors/pull/89#discussion_r75838420'>File: dbms/mysql/src/cloud/benchflow/collectors/mysql.go:L1-81</a></b>
- <a href='https://github.com/VincenzoFerme'><img border=0 src='https://avatars.githubusercontent.com/u/7163641?v=3' height=16 width=16'></a> You are not removing the sql file
- <a href='https://github.com/Cerfoglg'><img border=0 src='https://avatars.githubusercontent.com/u/8819678?v=3' height=16 width=16'></a> @VincenzoFerme When you gzip something it overwirtes the uncompressed file, so I only have to remove the gzipped file because that's all there is.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/benchflow/collectors/pull/89#issuecomment-241689267'>General Comment</a></b>
- <a href='https://github.com/VincenzoFerme'><img border=0 src='https://avatars.githubusercontent.com/u/7163641?v=3' height=16 width=16'></a> Missing from https://github.com/benchflow/collectors/issues/85:
- The structure of the response is not as described. Moreover it should be placed in commons.
- Of course the same information should be printed on the standard output of the collectors
- <a href='https://github.com/Cerfoglg'><img border=0 src='https://avatars.githubusercontent.com/u/8819678?v=3' height=16 width=16'></a> @VincenzoFerme Altered the structure to fit the issue description

<a href='https://www.codereviewhub.com/benchflow/collectors/pull/89?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/benchflow/collectors/pull/89?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/benchflow/collectors/pull/89'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
